### PR TITLE
[feat] ax-ingest: research output auto-detection (v1.4.0)

### DIFF
--- a/adapters/ingest-research.sh
+++ b/adapters/ingest-research.sh
@@ -10,6 +10,9 @@
 #   AUTO_REVIEW.md             → research-notes (paper review)
 #   NARRATIVE_REPORT.md        → research-notes (research narrative)
 #   refine-logs/FINAL_PROPOSAL.md → research-notes (experiment proposal)
+#   IDEA_REPORT.md             → research-notes (idea-discovery output)
+#   LITERATURE_REPORT.md       → research-notes (research-lit output)
+#   eval_results.json          → experiment-log.md (run-experiment output)
 
 set -euo pipefail
 CONTENT_FILE=""
@@ -23,6 +26,13 @@ MEMORY="$PROJECT_ROOT/.ax/memory/MEMORY.md"
 # shellcheck source=../lib/ax-utils.sh
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../lib/ax-utils.sh"
 
+# Determine target for research notes (split memory → research-notes.md, legacy → MEMORY.md)
+RESEARCH_TARGET="$PROJECT_ROOT/.ax/memory/research-notes.md"
+if [ ! -f "$RESEARCH_TARGET" ]; then
+  RESEARCH_TARGET="$MEMORY"
+fi
+RESEARCH_SECTION="research-notes"
+
 # File → (label, section) mapping
 declare -A RESEARCH_FILES=(
   ["PAPER_PLAN.md"]="Paper Plan"
@@ -32,13 +42,15 @@ declare -A RESEARCH_FILES=(
   ["AUTO_REVIEW.md"]="Paper Review"
   ["NARRATIVE_REPORT.md"]="Research Narrative"
   ["refine-logs/FINAL_PROPOSAL.md"]="Experiment Proposal"
+  ["IDEA_REPORT.md"]="Idea Discovery Report"
+  ["LITERATURE_REPORT.md"]="Literature Report"
 )
 
 CONTENT_FILE=$(mktemp)
-ax_get_section "$MEMORY" "research-notes" \
+ax_get_section "$RESEARCH_TARGET" "$RESEARCH_SECTION" \
   | grep -v '^_No research notes yet' > "$CONTENT_FILE" || true
 
-mapfile -t EXISTING_IDS < <(ax_get_entry_ids "$MEMORY" "research-notes")
+mapfile -t EXISTING_IDS < <(ax_get_entry_ids "$RESEARCH_TARGET" "$RESEARCH_SECTION")
 
 NEW_COUNT=0
 
@@ -72,10 +84,48 @@ for REL_PATH in "${!RESEARCH_FILES[@]}"; do
 done
 
 if [ "$NEW_COUNT" -gt 0 ]; then
-  ax_replace_section "$MEMORY" "research-notes" "$CONTENT_FILE"
+  ax_replace_section "$RESEARCH_TARGET" "$RESEARCH_SECTION" "$CONTENT_FILE"
 elif [ ! -s "$CONTENT_FILE" ]; then
   printf '_No research notes yet._\n' > "$CONTENT_FILE"
-  ax_replace_section "$MEMORY" "research-notes" "$CONTENT_FILE"
+  ax_replace_section "$RESEARCH_TARGET" "$RESEARCH_SECTION" "$CONTENT_FILE"
 fi
 
 rm -f "$CONTENT_FILE"
+
+# Handle eval_results.json → experiment-log.md
+EVAL_JSON="$PROJECT_ROOT/eval_results.json"
+if [ -f "$EVAL_JSON" ]; then
+  MTIME=$(stat -c %Y "$EVAL_JSON" 2>/dev/null || echo 0)
+  ENTRY_ID="${MTIME}-eval-results-json"
+
+  # Check against experiment-log.md existing IDs
+  EXPLOG="$PROJECT_ROOT/.ax/memory/experiment-log.md"
+  if [ -f "$EXPLOG" ]; then
+    EXISTING_EXP_IDS=$(ax_get_entry_ids "$EXPLOG" "experiment-log" 2>/dev/null || true)
+    if ! printf '%s\n' "$EXISTING_EXP_IDS" | grep -qF "$ENTRY_ID" 2>/dev/null; then
+      FILE_DATE=$(date -d "@$MTIME" +%Y-%m-%d 2>/dev/null || date +%Y-%m-%d)
+      # Extract key metrics from JSON
+      SUMMARY=$(python3 -c "
+import json, sys
+try:
+  with open('$EVAL_JSON') as f:
+    d = json.load(f)
+  keys = list(d.keys())[:5]
+  parts = [f'{k}={d[k]}' for k in keys if isinstance(d[k], (int, float, str))]
+  print(', '.join(parts[:3]))
+except Exception as e:
+  print('(parse error)')
+" 2>/dev/null || echo "(no summary)")
+
+      EXP_CONTENT=$(mktemp)
+      ax_get_section "$EXPLOG" "experiment-log" \
+        | grep -v '^_No experiments recorded yet' > "$EXP_CONTENT" || true
+      {
+        printf '<!-- entry:%s -->\n' "$ENTRY_ID"
+        printf '- **%s** eval_results.json: %s\n' "$FILE_DATE" "$SUMMARY"
+      } >> "$EXP_CONTENT"
+      ax_replace_section "$EXPLOG" "experiment-log" "$EXP_CONTENT"
+      rm -f "$EXP_CONTENT"
+    fi
+  fi
+fi


### PR DESCRIPTION
## Summary

- `ingest-research.sh`에 IDEA_REPORT.md, LITERATURE_REPORT.md 감지 추가 → research-notes
- `ingest-research.sh`에 eval_results.json 감지 추가 → experiment-log.md
- split memory (#7) 적용 시 research-notes.md, decisions.md에 분리 저장
- `/ax learn`: decisions.md 파일이 있으면 그쪽에 저장, 없으면 MEMORY.md fallback

## Test plan

- [ ] IDEA_REPORT.md 생성 후 SessionEnd 시 research-notes에 항목 추가 확인
- [ ] LITERATURE_REPORT.md 생성 후 research-notes 항목 추가 확인
- [ ] eval_results.json 생성 후 experiment-log.md에 항목 추가 확인
- [ ] `/ax learn 테스트` → decisions.md에 저장 확인
- [ ] VERSION, plugin.json, marketplace.json 모두 1.4.0 확인

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)